### PR TITLE
Raspberry config regression

### DIFF
--- a/arm-rpi/rpi-firmware-boot/autobuild/overrides/usr/lib/rpi64/config/config.txt
+++ b/arm-rpi/rpi-firmware-boot/autobuild/overrides/usr/lib/rpi64/config/config.txt
@@ -1,0 +1,82 @@
+# For more options and information see
+# http://rpf.io/configtxt
+# Some settings may impact device functionality. See link above for details
+
+# uncomment if you get no picture on HDMI for a default "safe" mode
+#hdmi_safe=1
+
+# uncomment the following to adjust overscan. Use positive numbers if console
+# goes off screen, and negative if there is too much border
+#overscan_left=16
+#overscan_right=16
+#overscan_top=16
+#overscan_bottom=16
+
+# uncomment to force a console size. By default it will be display's size minus
+# overscan.
+#framebuffer_width=1280
+#framebuffer_height=720
+
+# uncomment if hdmi display is not detected and composite is being output
+#hdmi_force_hotplug=1
+
+# uncomment to force a specific HDMI mode (this will force VGA)
+#hdmi_group=1
+#hdmi_mode=1
+
+# uncomment to force a HDMI mode rather than DVI. This can make audio work in
+# DMT (computer monitor) modes
+#hdmi_drive=2
+
+# uncomment to increase signal to HDMI, if you have interference, blanking, or
+# no display
+#config_hdmi_boost=4
+
+# uncomment for composite PAL
+#sdtv_mode=2
+
+#uncomment to overclock the arm. 700 MHz is the default.
+#arm_freq=800
+
+# Uncomment some or all of these to enable the optional hardware interfaces
+#dtparam=i2c_arm=on
+#dtparam=i2s=on
+#dtparam=spi=on
+
+# Uncomment this to enable infrared communication.
+#dtoverlay=gpio-ir,gpio_pin=17
+#dtoverlay=gpio-ir-tx,gpio_pin=18
+
+# Additional overlays and parameters are documented /boot/overlays/README
+
+# Enable audio (loads snd_bcm2835)
+dtparam=audio=on
+
+# Automatically load overlays for detected cameras
+camera_auto_detect=1
+
+# Automatically load overlays for detected DSI displays
+display_auto_detect=1
+
+# Enable DRM VC4 V3D driver
+dtoverlay=vc4-kms-v3d
+
+# Run in 64-bit mode
+arm_64bit=1
+
+# Disable compensation for displays with overscan
+disable_overscan=1
+
+[cm4]
+# Enable host mode on the 2711 built-in XHCI USB controller.
+# This line should be removed if the legacy DWC2 controller is required
+# (e.g. for USB device mode) or if USB support is not required.
+otg_mode=1
+
+[pi4]
+# Run as fast as firmware / board allows
+arm_boost=1
+max_framebuffers=2
+
+[all]
+include distcfg.txt

--- a/arm-rpi/rpi-firmware-boot/autobuild/overrides/usr/lib/rpi64/config/distcfg.txt
+++ b/arm-rpi/rpi-firmware-boot/autobuild/overrides/usr/lib/rpi64/config/distcfg.txt
@@ -1,0 +1,12 @@
+# Distribution specific config
+
+# Make sure Pi will execute 64-bit kernel
+arm_64bit=1
+
+# Kernel image name
+kernel=kernel8.img
+
+# Uncomment this for initrd support
+# You should copy your initrd to boot partition before enabling initrd
+# initramfs initrd.img followkernel
+

--- a/arm-rpi/rpi-firmware-boot/autobuild/postinst
+++ b/arm-rpi/rpi-firmware-boot/autobuild/postinst
@@ -16,114 +16,25 @@ if [ -e /boot/rpi/kernel8.img ]; then
 else
   echo "Copying kernel and firmware..."
   cp -r /usr/lib/rpi64/boot/* /boot/rpi/
+  cp -r /usr/lib/rpi64/kernel/* /boot/rpi/
 fi
 
 if [ ! -e /boot/rpi/config.txt ]; then
   echo "Creating config.txt..."
-  cat > /boot/rpi/config.txt << 'EOF'
-# For more options and information see
-# http://rpf.io/configtxt
-# Some settings may impact device functionality. See link above for details
-
-
-# uncomment if you get no picture on HDMI for a default "safe" mode
-# hdmi_safe=1
-
-# uncomment this if your display has a black border of unused pixels visible
-# and your display can output without overscan
-disable_overscan=1
-
-# uncomment the following to adjust overscan. Use positive numbers if console
-# goes off screen, and negative if there is too much border
-#overscan_left=16
-#overscan_right=16
-#overscan_top=16
-#overscan_bottom=16
-
-# uncomment to force a console size. By default it will be display's size minus
-# overscan.
-# framebuffer_width=1280
-# framebuffer_height=720
-
-# uncomment if hdmi display is not detected and composite is being output
-# hdmi_force_hotplug=1
-
-# uncomment to force a specific HDMI mode (this will force VGA)
-# hdmi_group=2
-# hdmi_mode=85
-
-# uncomment to force a HDMI mode rather than DVI. This can make audio work in
-# DMT (computer monitor) modes
-# hdmi_drive=2
-# gpu_mem=320
-
-# uncomment to increase signal to HDMI, if you have interference, blanking, or
-# no display
-#config_hdmi_boost=4
-
-# uncomment for composite PAL
-#sdtv_mode=2
-
-#uncomment to overclock the arm. 700 MHz is the default.
-#arm_freq=800
-
-# Uncomment some or all of these to enable the optional hardware interfaces
-# dtparam=i2c_arm=on
-# dtparam=i2s=on
-# dtparam=spi=on
-
-# Uncomment this to enable infrared communication.
-# dtoverlay=gpio-ir,gpio_pin=17
-# dtoverlay=gpio-ir-tx,gpio_pin=18
-enable_uart=1
-# Additional overlays and parameters are documented /boot/overlays/README
-
-# Enable audio (loads snd_bcm2835)
-dtparam=audio=on
-
-arm_64bit=1
-
-# Debug options
-# start_file=start_db.elf
-# start_debug=1
-
-[pi4]
-# Enable DRM VC4 V3D driver on top of the dispmanx display stack
-dtoverlay=vc4-fkms-v3d
-max_framebuffers=2
-
-# Uncomment this to overclock your SoC
-# Up to 1.8GHz
-# arm_boost=1
-
-# Uncomment this for autoloading Bluetooth UART
-# dtparam=krnbt=on
-
-[all]
-dtoverlay=vc4-fkms-v3d
-include distcfg.txt
-EOF
-
+  cp /usr/lib/rpi64/config/config.txt /boot/rpi/config.txt
 fi
 
 if [ "$ARM_BOOST" == "1" ]; then
-  sed -e 's/^#\ arm_boost=1/arm_boost=1/g' -i /boot/rpi/config.txt
+  sed -e 's/^#arm_boost=1/arm_boost=1/g' -i /boot/rpi/config.txt
 fi
-
 
 if [ ! -e /boot/rpi/distcfg.txt ]; then
   echo "Creating distcfg.txt..."
-  cat > /boot/rpi/distcfg.txt << 'EOF'
-arm_64bit=1
-kernel=kernel8.img
-# Uncomment this for initrd support
-# You should copy your initrd to boot partition before enabling initrd
-# initramfs initrd.img followkernel
-EOF
+  cp /usr/lib/rpi64/config/distcfg.txt /boot/rpi/distcfg.txt
 fi
 
 if [ ! -e /boot/rpi/cmdline.txt ]; then
   PARTUUID="$(lsblk -x MOUNTPOINT -o MOUNTPOINT,PARTUUID | egrep '^/\s' | awk '{print $2}')"
   echo "Generating new cmdline.txt..."
-  echo -n "root=PARTUUID=${PARTUUID} rw elevator=deadline fsck.repair=yes rootwait" > /boot/rpi/cmdline.txt
+  echo -n "console=serial0,115200 console=tty1 root=PARTUUID=${PARTUUID} rw elevator=deadline fsck.repair=yes rootwait" > /boot/rpi/cmdline.txt
 fi

--- a/arm-rpi/rpi-firmware-boot/spec
+++ b/arm-rpi/rpi-firmware-boot/spec
@@ -1,4 +1,5 @@
 VER="1.20211109"
+REL=1
 COMMIT="fa9a00624e7d5d3dcdb297dff132dc32cc2d9a25"
 SRCS="tbl::https://github.com/raspberrypi/firmware/archive/$COMMIT.tar.gz"
 CHKSUMS="sha256::a079a31fc80a23421589edcacef94faa713b12d3e77b92710ae2594c8d549477"


### PR DESCRIPTION
Description
------

This PR reworks the config.txt generation. The config.txt is moved to a separate file in order to make aosc-mkrawimg happy - it can now directly copy corresponding files to the boot partition.

This PR also changes `console=` kernel command line parameters. `cmdline.txt` has to be generated, sorry. aosc-mkrawimg does cover this though.